### PR TITLE
Avoid dupe node-mapnik

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,7 @@ var Memcheck = require('./memcheck');
 var byteConvert = require('./memcheck').byteConvert;
 var tilelive = require('tilelive');
 var File = require('tilelive-file');
-var omnivore = require('tilelive-omnivore');
-var getMetadata = require('mapnik-omnivore').digest;
+var cp = require('child_process');
 
 module.exports = bench;
 
@@ -83,9 +82,7 @@ function bench(src, version, options, callback) {
   var mapnik_modules = Object.keys(require.cache).filter(function(p) {
     // we are using tilelive-omnivore & mapnik-omnivore for utiliy functions
     // and never touch their mapnik instance
-    return (p.indexOf('mapnik.js') > -1 && 
-            p.indexOf('tilelive-omnivore') === -1 && 
-            p.indexOf('mapnik-omnivore') === -1);
+    return (p.indexOf('mapnik.js') > -1);
   });
   if (mapnik_modules.length > 1) {
     console.log(mapnik_modules);
@@ -158,10 +155,16 @@ function bench(src, version, options, callback) {
  *
  */
 function generateXML(filepath, callback) {
-  getMetadata(filepath, function(err, metadata) {
-    if (err) return callback(err);
-    metadata.filepath = filepath;
-    return callback(null, omnivore.getXml(metadata));
+  var args = [
+    path.join(path.dirname(require.resolve('tilelive-omnivore')),'bin/mapnik-omnivore'),
+    path.resolve(filepath)
+  ];
+  var options = {};
+  cp.execFile(process.execPath, args, options, function(err, stdout, stderr) {
+    if (err) {
+        return callback(err);
+    }
+    return callback(null,stdout.toString());
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "Mapbox",
   "dependencies": {
     "bytes": "^2.1.0",
-    "mapnik-omnivore": "^7.3.0",
     "mapnik-pool": "0.1.3",
     "minimist": "0.2.0",
     "mkdirp": "0.5.1",


### PR DESCRIPTION
This ensures that the specific mapnik version requested on the command line is actually the one used. Without this that is not certain after including `tilelive-omnivore` and `mapnik-omnivore` which themselves do `require('mapnik')`.

We don't want to have to version both of these deps like we do `tilelive-bridge`, so this is a cheap solution to avoid their mapnik version needing to matter.

/cc @mapsam
