### PR TITLE
Set the threadpool right at script startup

### DIFF
--- a/bin/bench.js
+++ b/bin/bench.js
@@ -2,10 +2,30 @@
 
 'use strict';
 
+var argv = require('minimist')(process.argv.slice(2));
+
+/* Set the node.js threadpool
+ *
+ * It is important that we set this before any async work is triggered as
+ * my understanding (dane) is that the value is cached once the threadpool
+ * is created inside node
+ *
+ * the size defaults to 4, which is quite small and we can get better performance if we
+ * bump it up to something default or 1.5 times the CPU power on your machine
+ *
+ * recording threadpool size is important because it can have drastic
+ * effects on the benchmark output
+ */
+if (args.threadpool) {
+  process.env.UV_THREADPOOL_SIZE = args.threadpool;
+} else {
+  var size = Math.ceil(Math.max(4, os.cpus().length * 1.5));
+  process.env.UV_THREADPOOL_SIZE = size;
+}
+
 var bench = require('../lib/index.js');
 var fs = require('fs');
 var fixtures = require('../testcases/index.js');
-var argv = require('minimist')(process.argv.slice(2));
 var usage = fs.readFileSync(__dirname+ '/usage').toString();
 
 // usage

--- a/bin/benchall.js
+++ b/bin/benchall.js
@@ -2,9 +2,30 @@
 
 'use strict';
 
+var argv = require('minimist')(process.argv.slice(2));
+
+/* Set the node.js threadpool
+ *
+ * It is important that we set this before any async work is triggered as
+ * my understanding (dane) is that the value is cached once the threadpool
+ * is created inside node
+ *
+ * the size defaults to 4, which is quite small and we can get better performance if we
+ * bump it up to something default or 1.5 times the CPU power on your machine
+ *
+ * recording threadpool size is important because it can have drastic
+ * effects on the benchmark output
+ */
+if (args.threadpool) {
+  process.env.UV_THREADPOOL_SIZE = args.threadpool;
+} else {
+  var size = Math.ceil(Math.max(4, os.cpus().length * 1.5));
+  process.env.UV_THREADPOOL_SIZE = size;
+}
+
 var bench = require('../lib/index.js');
 var fs = require('fs');
-var argv = require('minimist')(process.argv.slice(2));
+
 var usage = fs.readFileSync(__dirname+ '/usageall').toString();
 var path = require('path');
 var os = require('os');

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,21 +57,6 @@ function bench(src, version, options, callback) {
     }
   };
 
-  /* Set the node.js threadpool
-   *
-   * the size defaults to 4, which is quite small and we can get better performance if we
-   * bump it up to something default or 1.5 times the CPU power on your machine
-   * 
-   * recording threadpool size is important beacuse it can have drastic
-   * effects on the benchmark output
-   */
-  if (options.threadpool) {
-    process.env.UV_THREADPOOL_SIZE = options.threadpool;
-  } else {
-    var size = Math.ceil(Math.max(4, os.cpus().length * 1.5));
-    process.env.UV_THREADPOOL_SIZE = options.threadpool = size;
-  }
-
   /*
    * Prepare Node Mapnik version
    */


### PR DESCRIPTION
According to https://github.com/joyent/libuv/issues/649#issuecomment-16995081 it is dubious whether setting `process.env.UV_THREADPOOL_SIZE` works at all. The concern is that for node to respect the option you'd need to se `UV_THREADPOOL_SIZE` in the shell environment before node starts.

However I've seen that setting `process.env.UV_THREADPOOL_SIZE` at the top of the main script works fine. This change moves the setting of `process.env.UV_THREADPOOL_SIZE` to the top of the benchmark scripts to ensure the best change that the option is respected. I don't have proof that it was not being respected previously, but this is also a hard thing to test so I think this modification is the best bet.

/cc @mapsam @BergWerkGIS 
